### PR TITLE
Fix Field table IDs

### DIFF
--- a/jql-core/src/main/java/io/github/benas/jql/domain/FieldDao.java
+++ b/jql-core/src/main/java/io/github/benas/jql/domain/FieldDao.java
@@ -35,7 +35,7 @@ public class FieldDao extends BaseDao {
     public int save(Field field) {
         int fieldId = getNextId("FIELD");
         jdbcTemplate.update("insert into FIELD values (?,?,?,?,?,?,?,?)",
-                field.getId(), field.getName(), field.getType(),
+                fieldId, field.getName(), field.getType(),
                 toSqliteBoolean(field.isPublic()), toSqliteBoolean(field.isStatic()), toSqliteBoolean(field.isFinal()), toSqliteBoolean(field.isTransient()), field.getTypeId());
         return fieldId;
     }


### PR DESCRIPTION
The generated ID was not used: all IDs in the `Field` table were `0` in the database.
