### PR TITLE
Upgrade the JavaParser dependency

### DIFF
--- a/jql-core/src/main/java/io/github/benas/jql/core/AnnotationMemberIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/AnnotationMemberIndexer.java
@@ -38,9 +38,8 @@ public class AnnotationMemberIndexer {
     }
 
     public void index(AnnotationMemberDeclaration annotationMemberDeclaration, int typeId) {
-        int annotationMemberModifiers = annotationMemberDeclaration.getModifiers();
-        methodDao.save(new Method(annotationMemberDeclaration.getName(),
-                isPublic(annotationMemberModifiers), isStatic(annotationMemberModifiers), isFinal(annotationMemberModifiers), isAbstract(annotationMemberModifiers), false, typeId));
+        methodDao.save(new Method(annotationMemberDeclaration.getNameAsString(),
+                annotationMemberDeclaration.isPublic(), false, false, annotationMemberDeclaration.isAbstract(), false, typeId));
     }
 
 }

--- a/jql-core/src/main/java/io/github/benas/jql/core/CompilationUnitIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/CompilationUnitIndexer.java
@@ -24,6 +24,7 @@
 package io.github.benas.jql.core;
 
 import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import io.github.benas.jql.domain.CompilationUnitDao;
 
 import java.util.List;
@@ -40,11 +41,11 @@ public class CompilationUnitIndexer {
     }
 
     public void index(com.github.javaparser.ast.CompilationUnit compilationUnit, String fileName) {
-        String packageName = compilationUnit.getPackage() != null ? compilationUnit.getPackage().getPackageName() : "";
+        String packageName = compilationUnit.getPackageDeclaration().map(NodeWithName::getNameAsString).orElse("");
         io.github.benas.jql.model.CompilationUnit cu = new io.github.benas.jql.model.CompilationUnit(fileName, packageName);
         int cuId =  compilationUnitDao.save(cu);
-        List<TypeDeclaration> types = compilationUnit.getTypes();
-        for (TypeDeclaration type : types) {
+        List<TypeDeclaration<?>> types = compilationUnit.getTypes();
+        for (TypeDeclaration<?> type : types) {
             typeIndexer.index(type, cuId);
         }
     }

--- a/jql-core/src/main/java/io/github/benas/jql/core/ConstructorIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/ConstructorIndexer.java
@@ -43,11 +43,10 @@ public class ConstructorIndexer {
     }
 
     public void index(ConstructorDeclaration constructorDeclaration, int typeId) {
-        int modifiers = constructorDeclaration.getModifiers();
         List<Parameter> parameters = constructorDeclaration.getParameters();
-        String name = constructorDeclaration.getName();
+        String name = constructorDeclaration.getNameAsString();
         int methodId = methodDao.save(new Method(name,
-                isPublic(modifiers), isStatic(modifiers), isFinal(modifiers), isAbstract(modifiers), true, typeId));
+                constructorDeclaration.isPublic(), constructorDeclaration.isStatic(), constructorDeclaration.isFinal(), constructorDeclaration.isAbstract(), true, typeId));
         for (Parameter parameter : parameters) {
             parameterIndexer.index(parameter, methodId);
         }

--- a/jql-core/src/main/java/io/github/benas/jql/core/EntityIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/EntityIndexer.java
@@ -24,6 +24,7 @@
 package io.github.benas.jql.core;
 
 import com.github.javaparser.ParseException;
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
 
 import java.io.File;
@@ -48,7 +49,7 @@ public class EntityIndexer {
             try {
                 CompilationUnit cu = parse(file);
                 compilationUnitIndexer.index(cu, file.getName());
-            } catch (ParseException | IOException e) {
+            } catch (ParseProblemException | IOException e) {
                 System.err.println("Error while parsing " + file.getAbsolutePath());
             }
             System.out.print("\rIndexing entities: " + getPercent(fileIndex, totalFiles) + "% " + ("(" + fileIndex + "/" + totalFiles + ")"));

--- a/jql-core/src/main/java/io/github/benas/jql/core/FieldIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/FieldIndexer.java
@@ -30,9 +30,7 @@ import io.github.benas.jql.model.Field;
 
 import java.util.List;
 
-import static java.lang.reflect.Modifier.*;
-
-    public class FieldIndexer {
+public class FieldIndexer {
 
     private FieldDao fieldDao;
 
@@ -41,12 +39,11 @@ import static java.lang.reflect.Modifier.*;
     }
 
     public void index(FieldDeclaration fieldDeclaration, int typeId) {
-        int fieldModifiers = fieldDeclaration.getModifiers();
         List<VariableDeclarator> variables = fieldDeclaration.getVariables();
         for (VariableDeclarator variable : variables) {
-            String name = variable.getId().getName();
-            fieldDao.save(new Field(name, fieldDeclaration.getType().toString(),
-                    isPublic(fieldModifiers), isStatic(fieldModifiers), isFinal(fieldModifiers), isTransient(fieldModifiers), typeId));
+            String name = variable.getNameAsString();
+            fieldDao.save(new Field(name, fieldDeclaration.getElementType().asString(),
+                    fieldDeclaration.isPublic(), fieldDeclaration.isStatic(), fieldDeclaration.isFinal(), fieldDeclaration.isTransient(), typeId));
         }
     }
 

--- a/jql-core/src/main/java/io/github/benas/jql/core/MethodIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/MethodIndexer.java
@@ -43,11 +43,10 @@ public class MethodIndexer {
     }
 
     public void index(MethodDeclaration methodDeclaration, int typeId) {
-        int methodModifiers = methodDeclaration.getModifiers();
         List<Parameter> parameters = methodDeclaration.getParameters();
-        String name = methodDeclaration.getName();
+        String name = methodDeclaration.getNameAsString();
         int methodId = methodDao.save(new Method(name,
-                isPublic(methodModifiers), isStatic(methodModifiers), isFinal(methodModifiers), isAbstract(methodModifiers), false, typeId));
+                methodDeclaration.isPublic(), methodDeclaration.isStatic(), methodDeclaration.isFinal(), methodDeclaration.isAbstract(), false, typeId));
         for (Parameter parameter : parameters) {
             parameterIndexer.index(parameter, methodId);
         }

--- a/jql-core/src/main/java/io/github/benas/jql/core/ParameterIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/ParameterIndexer.java
@@ -34,7 +34,7 @@ public class ParameterIndexer {
     }
 
     public void index(com.github.javaparser.ast.body.Parameter parameter, int methodId) {
-        io.github.benas.jql.model.Parameter p = new io.github.benas.jql.model.Parameter(parameter.getId().getName(), parameter.getType().toString(), methodId);
+        io.github.benas.jql.model.Parameter p = new io.github.benas.jql.model.Parameter(parameter.getNameAsString(), parameter.getType().asString(), methodId);
         parameterDao.save(p);
     }
 }

--- a/jql-core/src/main/java/io/github/benas/jql/core/RelationCalculator.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/RelationCalculator.java
@@ -24,7 +24,9 @@
 package io.github.benas.jql.core;
 
 import com.github.javaparser.ParseException;
+import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
@@ -57,8 +59,8 @@ public class RelationCalculator {
         for (File file : files) {
             try {
                 CompilationUnit cu = parse(file);
-                List<TypeDeclaration> types = cu.getTypes();
-                for (TypeDeclaration type : types) {
+                NodeList<TypeDeclaration<?>> types = cu.getTypes();
+                for (TypeDeclaration<?> type : types) {
                     boolean isInterface = type instanceof ClassOrInterfaceDeclaration && ((ClassOrInterfaceDeclaration) type).isInterface();
                     boolean isAnnotation = type instanceof AnnotationDeclaration;
                     boolean isEnumeration = type instanceof EnumDeclaration;
@@ -79,7 +81,7 @@ public class RelationCalculator {
                         annotatedWithCalculator.calculate((ClassOrInterfaceDeclaration) type, cu);
                     }
                 }
-            } catch (ParseException | IOException e) {
+            } catch (ParseProblemException | IOException e) {
                 System.err.println("Error while parsing " + file.getAbsolutePath());
             }
             System.out.print("\rCalculating relations: " + getPercent(fileIndex, totalFiles) + "% " + ("(" + fileIndex + "/" + totalFiles + ")"));

--- a/jql-core/src/main/java/io/github/benas/jql/core/TypeIndexer.java
+++ b/jql-core/src/main/java/io/github/benas/jql/core/TypeIndexer.java
@@ -23,11 +23,14 @@
  */
 package io.github.benas.jql.core;
 
+import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.body.*;
 import io.github.benas.jql.domain.TypeDao;
 import io.github.benas.jql.model.Type;
 
-import static java.lang.reflect.Modifier.*;
+import java.util.EnumSet;
+
+import static com.github.javaparser.ast.Modifier.*;
 
 public class TypeIndexer {
 
@@ -40,14 +43,14 @@ public class TypeIndexer {
         this.bodyDeclarationIndexer = bodyDeclarationIndexer;
     }
 
-    public void index(TypeDeclaration type, int cuId) {
-        int modifiers = type.getModifiers();
+    public void index(TypeDeclaration<?> type, int cuId) {
+        EnumSet<Modifier> modifiers = type.getModifiers();
         boolean isInterface = type instanceof ClassOrInterfaceDeclaration && ((ClassOrInterfaceDeclaration) type).isInterface();
         boolean isAnnotation = type instanceof AnnotationDeclaration;
         boolean isEnumeration = type instanceof EnumDeclaration;
         boolean isClass = !isAnnotation && !isEnumeration && !isInterface;
-
-        Type t = new Type(type.getName(), isPublic(modifiers), isStatic(modifiers), isFinal(modifiers), isAbstract(modifiers), isClass, isInterface, isEnumeration, isAnnotation, cuId);
+        
+        Type t = new Type(type.getNameAsString(), type.isPublic(), type.isStatic(), modifiers.contains(FINAL), modifiers.contains(ABSTRACT), isClass, isInterface, isEnumeration, isAnnotation, cuId);
         int typeId = typeDao.save(t);
 
         for (BodyDeclaration member : type.getMembers()) {

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <javaparser-core.version>2.4.0</javaparser-core.version>
+        <javaparser-core.version>3.5.2</javaparser-core.version>
         <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
         <commons-io.version>2.5</commons-io.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
There are a *lot* of known bugs in JavaParser 2.4.0, making this a rather urgent upgrade.